### PR TITLE
Add getter to extract hd for G Suite domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ information contained in the token via the following instance methods:
 
 * `locale`
 
-* `hd`: The hosted G Suite domain of the user, provided only if user belongs to a hosted domain.
+* `hosted_domain`: The hosted G Suite domain of the user, provided only if user belongs to a hosted domain.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ information contained in the token via the following instance methods:
 
 * `locale`
 
+* `hd`: The hosted G Suite domain of the user, provided only if user belongs to a hosted domain.
 
 ## Security
 

--- a/lib/google_sign_in/identity.rb
+++ b/lib/google_sign_in/identity.rb
@@ -36,6 +36,10 @@ module GoogleSignIn
       @payload["locale"]
     end
 
+    def hd
+      @payload["hd"]
+    end
+
     private
       delegate :client_id, to: GoogleSignIn
 

--- a/lib/google_sign_in/identity.rb
+++ b/lib/google_sign_in/identity.rb
@@ -36,7 +36,7 @@ module GoogleSignIn
       @payload["locale"]
     end
 
-    def hd
+    def hosted_domain
       @payload["hd"]
     end
 

--- a/test/models/identity_test.rb
+++ b/test/models/identity_test.rb
@@ -61,9 +61,10 @@ class GoogleSignIn::IdentityTest < ActiveSupport::TestCase
     assert_equal "en-US", GoogleSignIn::Identity.new(token_with(locale: "en-US")).locale
   end
 
-  test "extracting hd on google apps identity" do
-    assert_equal "basecamp.com", GoogleSignIn::Identity.new(g_suite_token_with(locale: "en-US")).hd
+  test "extracting hosted_domain on google apps identity" do
+    assert_equal "basecamp.com", GoogleSignIn::Identity.new(token_with(hd: "basecamp.com")).hosted_domain
   end
+
   private
     def switch_client_id_to(value)
       previous_value = GoogleSignIn.client_id
@@ -75,9 +76,5 @@ class GoogleSignIn::IdentityTest < ActiveSupport::TestCase
 
     def token_with(aud: FAKE_GOOGLE_CLIENT_ID, iss: "https://accounts.google.com", key: GOOGLE_PRIVATE_KEY, **payload)
       JWT.encode(payload.merge(aud: aud, iss: iss), key, "RS256")
-    end
-
-    def g_suite_token_with(aud: FAKE_GOOGLE_CLIENT_ID, iss: "https://accounts.google.com", key: GOOGLE_PRIVATE_KEY, **payload)
-      JWT.encode(payload.merge(aud: aud, iss: iss, hd: 'basecamp.com'), key, "RS256")
     end
 end

--- a/test/models/identity_test.rb
+++ b/test/models/identity_test.rb
@@ -61,6 +61,9 @@ class GoogleSignIn::IdentityTest < ActiveSupport::TestCase
     assert_equal "en-US", GoogleSignIn::Identity.new(token_with(locale: "en-US")).locale
   end
 
+  test "extracting hd on google apps identity" do
+    assert_equal "basecamp.com", GoogleSignIn::Identity.new(g_suite_token_with(locale: "en-US")).hd
+  end
   private
     def switch_client_id_to(value)
       previous_value = GoogleSignIn.client_id
@@ -72,5 +75,9 @@ class GoogleSignIn::IdentityTest < ActiveSupport::TestCase
 
     def token_with(aud: FAKE_GOOGLE_CLIENT_ID, iss: "https://accounts.google.com", key: GOOGLE_PRIVATE_KEY, **payload)
       JWT.encode(payload.merge(aud: aud, iss: iss), key, "RS256")
+    end
+
+    def g_suite_token_with(aud: FAKE_GOOGLE_CLIENT_ID, iss: "https://accounts.google.com", key: GOOGLE_PRIVATE_KEY, **payload)
+      JWT.encode(payload.merge(aud: aud, iss: iss, hd: 'basecamp.com'), key, "RS256")
     end
 end


### PR DESCRIPTION
G Suite users have a hd or Hosted Domain parameter which was not previously exposed. I currently make use of it in a yet to be released app.