### PR TITLE
Add a CHANGELOG.md file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+Please see [our GitHub "Releases" page](https://github.com/basecamp/google_sign_in/releases).


### PR DESCRIPTION
# About
Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), a CHANGELOG.md file can help the gem users with upgrades.

For now it's only release notes copied and pasted in it.

# Why this change

I recently had to do the upgrade from v0.1.4 to v1.1.1, it would have helped to have a CHANGELOG file with all the changes in one place.