### PR TITLE
Pass the access-token to the proceed_to_url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ This gem provides a `google_sign_in_button` helper. It generates a button which 
 ```
 
 The `proceed_to` argument is required. After authenticating with Google, the gem redirects to `proceed_to`, providing
-a Google ID token in `flash[:google_sign_in_token]`. Your application decides what to do with it:
+a Google ID token in `flash[:google_sign_in_token]` and the Google access-token in `flash[:google_sign_in_access_token]`.
+Your application decides what to do with it:
 
 ```ruby
 # config/routes.rb

--- a/app/controllers/google_sign_in/callbacks_controller.rb
+++ b/app/controllers/google_sign_in/callbacks_controller.rb
@@ -3,7 +3,7 @@ require_dependency 'google_sign_in/redirect_protector'
 class GoogleSignIn::CallbacksController < GoogleSignIn::BaseController
   def show
     if valid_request?
-      redirect_to proceed_to_url, flash: { google_sign_in_token: id_token }
+      redirect_to proceed_to_url, flash: { google_sign_in_token: id_token, google_sign_in_access_token: access_token }
     else
       head :unprocessable_entity
     end
@@ -21,7 +21,15 @@ class GoogleSignIn::CallbacksController < GoogleSignIn::BaseController
       flash[:proceed_to].tap { |url| GoogleSignIn::RedirectProtector.ensure_same_origin(url, request.url) }
     end
 
+    def oauth_access_token
+      @oauth_access_token ||= client.auth_code.get_token(params.require(:code))
+    end
+
     def id_token
-      client.auth_code.get_token(params.require(:code))['id_token']
+      oauth_access_token['id_token']
+    end
+
+    def access_token
+      oauth_access_token.token
     end
 end

--- a/test/controllers/callbacks_controller_test.rb
+++ b/test/controllers/callbacks_controller_test.rb
@@ -9,7 +9,9 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
 
     get google_sign_in.callback_url(code: '4/SgCpHSVW5-Cy', state: flash[:state])
     assert_redirected_to 'http://www.example.com/login'
+
     assert_equal 'eyJhbGciOiJSUzI', flash[:google_sign_in_token]
+    assert_equal 'ya29.GlwIBo', flash[:google_sign_in_access_token]
   end
 
   test "protecting against CSRF" do


### PR DESCRIPTION
Proposal for: https://github.com/basecamp/google_sign_in/issues/23

Do you want to consider `s/google_sign_in_token/google_sign_in_id_token/g` to make the label of this token explicit and match `google_sign_in_access_token` (I assume `google_sign_in` is some kind of name spacing within the `flash method)?