### PR TITLE
Add given name and family name to identity functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ information contained in the token via the following instance methods:
 
 * `hosted_domain`: The user’s hosted G Suite domain, provided only if they belong to a G Suite.
 
+* `given_name`: The user's given name.
+
+* `last_name`: The user's last name.
+
 
 ## Security
 

--- a/lib/google_sign_in/identity.rb
+++ b/lib/google_sign_in/identity.rb
@@ -40,6 +40,14 @@ module GoogleSignIn
       @payload["hd"]
     end
 
+    def given_name
+      @payload["given_name"]
+    end
+
+    def family_name
+      @payload["family_name"]
+    end
+
     private
       delegate :client_id, to: GoogleSignIn
 

--- a/test/models/identity_test.rb
+++ b/test/models/identity_test.rb
@@ -65,6 +65,14 @@ class GoogleSignIn::IdentityTest < ActiveSupport::TestCase
     assert_equal "basecamp.com", GoogleSignIn::Identity.new(token_with(hd: "basecamp.com")).hosted_domain
   end
 
+  test "extracting given name" do
+    assert_equal "George", GoogleSignIn::Identity.new(token_with(given_name: "George")).given_name
+  end
+
+  test "extracting family name" do
+    assert_equal "Claghorn", GoogleSignIn::Identity.new(token_with(family_name: "Claghorn")).family_name
+  end
+
   private
     def switch_client_id_to(value)
       previous_value = GoogleSignIn.client_id


### PR DESCRIPTION
In their response, google exposes `given_name` and `family_name`. See https://developers.google.com/identity/sign-in/web/server-side-flow at the very bottom of the page. 

The way I am using google_sign_in, I need access to this data and the cleanest way to get it would be for the gem itself to expose it.