### PR TITLE
Pass OAuth 2 errors through to the app as flash[:google_sign_in_error]

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ This gem provides a `google_sign_in_button` helper. It generates a button which 
 ```
 
 The `proceed_to` argument is required. After authenticating with Google, the gem redirects to `proceed_to`, providing
-a Google ID token in `flash[:google_sign_in_token]`. Your application decides what to do with it:
+a Google ID token in `flash[:google_sign_in_token]` or an [OAuth authorizaton code grant error](https://tools.ietf.org/html/rfc6749#section-4.1.2.1)
+in `flash[:google_sign_in_error]`. Your application decides what to do with it:
 
 ```ruby
 # config/routes.rb
@@ -108,8 +109,11 @@ class LoginsController < ApplicationController
 
   private
     def authenticate_with_google
-      if flash[:google_sign_in_token].present?
-        User.find_by google_id: GoogleSignIn::Identity.new(flash[:google_sign_in_token]).user_id
+      if id_token = flash[:google_sign_in_token]
+        User.find_by google_id: GoogleSignIn::Identity.new(id_token).user_id
+      elsif error = flash[:google_sign_in_error]
+        logger.error "Google authentication error: #{error}"
+        nil
       end
     end
 end

--- a/app/controllers/google_sign_in/callbacks_controller.rb
+++ b/app/controllers/google_sign_in/callbacks_controller.rb
@@ -2,31 +2,27 @@ require_dependency 'google_sign_in/redirect_protector'
 
 class GoogleSignIn::CallbacksController < GoogleSignIn::BaseController
   def show
-    if valid_request?
-      redirect_to proceed_to_url, flash: google_sign_in_response
-    else
-      head :unprocessable_entity
-    end
+    redirect_to proceed_to_url, flash: google_sign_in_response
   rescue GoogleSignIn::RedirectProtector::Violation => error
     logger.error error.message
     head :bad_request
   end
 
   private
-    def valid_request?
-      flash[:state].present? && params[:state] == flash[:state]
-    end
-
     def proceed_to_url
       flash[:proceed_to].tap { |url| GoogleSignIn::RedirectProtector.ensure_same_origin(url, request.url) }
     end
 
     def google_sign_in_response
-      if params[:code].present?
+      if valid_request? && params[:code].present?
         { google_sign_in_token: id_token }
       else
         { google_sign_in_error: error_message }
       end
+    end
+
+    def valid_request?
+      flash[:state].present? && params[:state] == flash[:state]
     end
 
     def id_token

--- a/app/controllers/google_sign_in/callbacks_controller.rb
+++ b/app/controllers/google_sign_in/callbacks_controller.rb
@@ -3,7 +3,7 @@ require_dependency 'google_sign_in/redirect_protector'
 class GoogleSignIn::CallbacksController < GoogleSignIn::BaseController
   def show
     if valid_request?
-      redirect_to proceed_to_url, flash: { google_sign_in_token: id_token }
+      redirect_to proceed_to_url, flash: google_sign_in_response
     else
       head :unprocessable_entity
     end
@@ -21,7 +21,19 @@ class GoogleSignIn::CallbacksController < GoogleSignIn::BaseController
       flash[:proceed_to].tap { |url| GoogleSignIn::RedirectProtector.ensure_same_origin(url, request.url) }
     end
 
+    def google_sign_in_response
+      if params[:code].present?
+        { google_sign_in_token: id_token }
+      else
+        { google_sign_in_error: error_message }
+      end
+    end
+
     def id_token
-      client.auth_code.get_token(params.require(:code))['id_token']
+      client.auth_code.get_token(params[:code])['id_token']
+    end
+
+    def error_message
+      params[:error].presence_in(GoogleSignIn::OAUTH2_ERRORS) || "invalid_request"
     end
 end

--- a/lib/google_sign_in.rb
+++ b/lib/google_sign_in.rb
@@ -5,7 +5,7 @@ module GoogleSignIn
   mattr_accessor :client_id
   mattr_accessor :client_secret
 
-  # https://tools.ietf.org/html/rfc6749#section-4.1.2.1
+  # Authorization Code Grant errors: https://tools.ietf.org/html/rfc6749#section-4.1.2.1
   OAUTH2_ERRORS = %w[
     invalid_request
     unauthorized_client

--- a/lib/google_sign_in.rb
+++ b/lib/google_sign_in.rb
@@ -4,6 +4,17 @@ require 'active_support/rails'
 module GoogleSignIn
   mattr_accessor :client_id
   mattr_accessor :client_secret
+
+  # https://tools.ietf.org/html/rfc6749#section-4.1.2.1
+  OAUTH2_ERRORS = %w[
+    invalid_request
+    unauthorized_client
+    access_denied
+    unsupported_response_type
+    invalid_scope
+    server_error
+    temporarily_unavailable
+  ]
 end
 
 require 'google_sign_in/identity'

--- a/test/controllers/callbacks_controller_test.rb
+++ b/test/controllers/callbacks_controller_test.rb
@@ -46,8 +46,13 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "protecting against CSRF without flash state" do
+    post google_sign_in.authorization_url, params: { proceed_to: 'http://www.example.com/login' }
+    assert_response :redirect
+
     get google_sign_in.callback_url(code: '4/SgCpHSVW5-Cy', state: 'invalid')
-    assert_response :unprocessable_entity
+    assert_redirected_to 'http://www.example.com/login'
+    assert_nil flash[:google_sign_in_token]
+    assert_equal 'invalid_request', flash[:google_sign_in_error]
   end
 
   test "protecting against CSRF with invalid state" do
@@ -56,7 +61,9 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil flash[:state]
 
     get google_sign_in.callback_url(code: '4/SgCpHSVW5-Cy', state: 'invalid')
-    assert_response :unprocessable_entity
+    assert_redirected_to 'http://www.example.com/login'
+    assert_nil flash[:google_sign_in_token]
+    assert_equal 'invalid_request', flash[:google_sign_in_error]
   end
 
   test "protecting against CSRF with missing state" do
@@ -65,7 +72,9 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil flash[:state]
 
     get google_sign_in.callback_url(code: '4/SgCpHSVW5-Cy')
-    assert_response :unprocessable_entity
+    assert_redirected_to 'http://www.example.com/login'
+    assert_nil flash[:google_sign_in_token]
+    assert_equal 'invalid_request', flash[:google_sign_in_error]
   end
 
   test "protecting against open redirects" do

--- a/test/controllers/callbacks_controller_test.rb
+++ b/test/controllers/callbacks_controller_test.rb
@@ -10,6 +10,39 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
     get google_sign_in.callback_url(code: '4/SgCpHSVW5-Cy', state: flash[:state])
     assert_redirected_to 'http://www.example.com/login'
     assert_equal 'eyJhbGciOiJSUzI', flash[:google_sign_in_token]
+    assert_nil flash[:google_sign_in_error]
+  end
+
+  GoogleSignIn::OAUTH2_ERRORS.each do |error|
+    test "receiving an authorization error: #{error}" do
+      post google_sign_in.authorization_url, params: { proceed_to: 'http://www.example.com/login' }
+      assert_response :redirect
+
+      get google_sign_in.callback_url(error: error, state: flash[:state])
+      assert_redirected_to 'http://www.example.com/login'
+      assert_nil flash[:google_sign_in_token]
+      assert_equal error, flash[:google_sign_in_error]
+    end
+  end
+
+  test "receiving an invalid authorization error" do
+    post google_sign_in.authorization_url, params: { proceed_to: 'http://www.example.com/login' }
+    assert_response :redirect
+
+    get google_sign_in.callback_url(error: 'unknown error code', state: flash[:state])
+    assert_redirected_to 'http://www.example.com/login'
+    assert_nil flash[:google_sign_in_token]
+    assert_equal "invalid_request", flash[:google_sign_in_error]
+  end
+
+  test "receiving neither code nor error" do
+    post google_sign_in.authorization_url, params: { proceed_to: 'http://www.example.com/login' }
+    assert_response :redirect
+
+    get google_sign_in.callback_url(state: flash[:state])
+    assert_redirected_to 'http://www.example.com/login'
+    assert_nil flash[:google_sign_in_token]
+    assert_equal 'invalid_request', flash[:google_sign_in_error]
   end
 
   test "protecting against CSRF without flash state" do


### PR DESCRIPTION
Rather than responding with 400 Bad Request due to missing `code` param.

Changes for apps to be aware of:
1. Apps may receive a callback with `flash[:google_sign_in_error]` set to one of the [OAuth 2 Authorization Code Grant errors](https://tools.ietf.org/html/rfc6749#section-4.1.2.1).
2. Mismatched `state` params are now passed to the app as errors so they can be treated as failed sign-ins.