### PR TITLE
Talk to the app via a consistent flash item that's always present

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ This gem provides a `google_sign_in_button` helper. It generates a button which 
 ```
 
 The `proceed_to` argument is required. After authenticating with Google, the gem redirects to `proceed_to`, providing
-a Google ID token in `flash[:google_sign_in_token]` or an [OAuth authorizaton code grant error](https://tools.ietf.org/html/rfc6749#section-4.1.2.1)
-in `flash[:google_sign_in_error]`. Your application decides what to do with it:
+a Google ID token in `flash[:google_sign_in][:id_token]` or an [OAuth authorizaton code grant error](https://tools.ietf.org/html/rfc6749#section-4.1.2.1)
+in `flash[:google_sign_in][:error]`. Your application decides what to do with it:
 
 ```ruby
 # config/routes.rb
@@ -109,9 +109,9 @@ class LoginsController < ApplicationController
 
   private
     def authenticate_with_google
-      if id_token = flash[:google_sign_in_token]
+      if id_token = flash[:google_sign_in][:id_token]
         User.find_by google_id: GoogleSignIn::Identity.new(id_token).user_id
-      elsif error = flash[:google_sign_in_error]
+      elsif error = flash[:google_sign_in][:error]
         logger.error "Google authentication error: #{error}"
         nil
       end

--- a/app/controllers/google_sign_in/callbacks_controller.rb
+++ b/app/controllers/google_sign_in/callbacks_controller.rb
@@ -15,9 +15,9 @@ class GoogleSignIn::CallbacksController < GoogleSignIn::BaseController
 
     def google_sign_in_response
       if valid_request? && params[:code].present?
-        { google_sign_in_token: id_token }
+        { google_sign_in: { id_token: id_token } }
       else
-        { google_sign_in_error: error_message }
+        { google_sign_in: { error: error_message } }
       end
     end
 

--- a/test/controllers/callbacks_controller_test.rb
+++ b/test/controllers/callbacks_controller_test.rb
@@ -9,8 +9,8 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
 
     get google_sign_in.callback_url(code: '4/SgCpHSVW5-Cy', state: flash[:state])
     assert_redirected_to 'http://www.example.com/login'
-    assert_equal 'eyJhbGciOiJSUzI', flash[:google_sign_in_token]
-    assert_nil flash[:google_sign_in_error]
+    assert_equal 'eyJhbGciOiJSUzI', flash[:google_sign_in][:id_token]
+    assert_nil flash[:google_sign_in][:error]
   end
 
   GoogleSignIn::OAUTH2_ERRORS.each do |error|
@@ -20,8 +20,8 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
 
       get google_sign_in.callback_url(error: error, state: flash[:state])
       assert_redirected_to 'http://www.example.com/login'
-      assert_nil flash[:google_sign_in_token]
-      assert_equal error, flash[:google_sign_in_error]
+      assert_nil flash[:google_sign_in][:id_token]
+      assert_equal error, flash[:google_sign_in][:error]
     end
   end
 
@@ -31,8 +31,8 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
 
     get google_sign_in.callback_url(error: 'unknown error code', state: flash[:state])
     assert_redirected_to 'http://www.example.com/login'
-    assert_nil flash[:google_sign_in_token]
-    assert_equal "invalid_request", flash[:google_sign_in_error]
+    assert_nil flash[:google_sign_in][:id_token]
+    assert_equal "invalid_request", flash[:google_sign_in][:error]
   end
 
   test "receiving neither code nor error" do
@@ -41,8 +41,8 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
 
     get google_sign_in.callback_url(state: flash[:state])
     assert_redirected_to 'http://www.example.com/login'
-    assert_nil flash[:google_sign_in_token]
-    assert_equal 'invalid_request', flash[:google_sign_in_error]
+    assert_nil flash[:google_sign_in][:id_token]
+    assert_equal 'invalid_request', flash[:google_sign_in][:error]
   end
 
   test "protecting against CSRF without flash state" do
@@ -51,8 +51,8 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
 
     get google_sign_in.callback_url(code: '4/SgCpHSVW5-Cy', state: 'invalid')
     assert_redirected_to 'http://www.example.com/login'
-    assert_nil flash[:google_sign_in_token]
-    assert_equal 'invalid_request', flash[:google_sign_in_error]
+    assert_nil flash[:google_sign_in][:id_token]
+    assert_equal 'invalid_request', flash[:google_sign_in][:error]
   end
 
   test "protecting against CSRF with invalid state" do
@@ -62,8 +62,8 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
 
     get google_sign_in.callback_url(code: '4/SgCpHSVW5-Cy', state: 'invalid')
     assert_redirected_to 'http://www.example.com/login'
-    assert_nil flash[:google_sign_in_token]
-    assert_equal 'invalid_request', flash[:google_sign_in_error]
+    assert_nil flash[:google_sign_in][:id_token]
+    assert_equal 'invalid_request', flash[:google_sign_in][:error]
   end
 
   test "protecting against CSRF with missing state" do
@@ -73,8 +73,8 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
 
     get google_sign_in.callback_url(code: '4/SgCpHSVW5-Cy')
     assert_redirected_to 'http://www.example.com/login'
-    assert_nil flash[:google_sign_in_token]
-    assert_equal 'invalid_request', flash[:google_sign_in_error]
+    assert_nil flash[:google_sign_in][:id_token]
+    assert_equal 'invalid_request', flash[:google_sign_in][:error]
   end
 
   test "protecting against open redirects" do


### PR DESCRIPTION
* Use `flash[:google_sign_in]` hash with `:id_token` and `:error` keys.
* Never nil, so we can always tell that we handled a Google sign-in.
* `flash[:google_sign_in_token]` could be nil, so it was hard to distinguish failed Google sign-ins from a non-Google requests.