### PR TITLE
Pass OAuth2 access token request errors through to the app

### DIFF
--- a/lib/google_sign_in.rb
+++ b/lib/google_sign_in.rb
@@ -5,8 +5,8 @@ module GoogleSignIn
   mattr_accessor :client_id
   mattr_accessor :client_secret
 
-  # Authorization Code Grant errors: https://tools.ietf.org/html/rfc6749#section-4.1.2.1
-  OAUTH2_ERRORS = %w[
+  # https://tools.ietf.org/html/rfc6749#section-4.1.2.1
+  authorization_request_errors = %w[
     invalid_request
     unauthorized_client
     access_denied
@@ -15,6 +15,20 @@ module GoogleSignIn
     server_error
     temporarily_unavailable
   ]
+
+  # https://tools.ietf.org/html/rfc6749#section-5.2
+  access_token_request_errors = %w[
+    invalid_request
+    invalid_client
+    invalid_grant
+    unauthorized_client
+    unsupported_grant_type
+    invalid_scope
+  ]
+
+  # Authorization Code Grant errors from both authorization requests
+  # and access token requests.
+  OAUTH2_ERRORS = authorization_request_errors | access_token_request_errors
 end
 
 require 'google_sign_in/identity'

--- a/test/controllers/callbacks_controller_test.rb
+++ b/test/controllers/callbacks_controller_test.rb
@@ -5,7 +5,7 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
     post google_sign_in.authorization_url, params: { proceed_to: 'http://www.example.com/login' }
     assert_response :redirect
 
-    stub_token_request code: '4/SgCpHSVW5-Cy', access_token: 'ya29.GlwIBo', id_token: 'eyJhbGciOiJSUzI'
+    stub_token_for '4/SgCpHSVW5-Cy', access_token: 'ya29.GlwIBo', id_token: 'eyJhbGciOiJSUzI'
 
     get google_sign_in.callback_url(code: '4/SgCpHSVW5-Cy', state: flash[:state])
     assert_redirected_to 'http://www.example.com/login'
@@ -13,8 +13,9 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
     assert_nil flash[:google_sign_in][:error]
   end
 
-  GoogleSignIn::OAUTH2_ERRORS.each do |error|
-    test "receiving an authorization error: #{error}" do
+  # Authorization request errors: https://tools.ietf.org/html/rfc6749#section-4.1.2.1
+  %w[ invalid_request unauthorized_client access_denied unsupported_response_type invalid_scope server_error temporarily_unavailable ].each do |error|
+    test "receiving an authorization code grant error: #{error}" do
       post google_sign_in.authorization_url, params: { proceed_to: 'http://www.example.com/login' }
       assert_response :redirect
 
@@ -43,6 +44,21 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to 'http://www.example.com/login'
     assert_nil flash[:google_sign_in][:id_token]
     assert_equal 'invalid_request', flash[:google_sign_in][:error]
+  end
+
+  # Access token request errors: https://tools.ietf.org/html/rfc6749#section-5.2
+  %w[ invalid_request invalid_client invalid_grant unauthorized_client unsupported_grant_type invalid_scope ].each do |error|
+    test "receiving an access token request error: #{error}" do
+      post google_sign_in.authorization_url, params: { proceed_to: 'http://www.example.com/login' }
+      assert_response :redirect
+
+      stub_token_error_for '4/SgCpHSVW5-Cy', error: error
+
+      get google_sign_in.callback_url(code: '4/SgCpHSVW5-Cy', state: flash[:state])
+      assert_redirected_to 'http://www.example.com/login'
+      assert_nil flash[:google_sign_in][:id_token]
+      assert_equal error, flash[:google_sign_in][:error]
+    end
   end
 
   test "protecting against CSRF without flash state" do
@@ -86,11 +102,27 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
   end
 
   private
-    def stub_token_request(code:, **params)
-      stub_request(:post, 'https://oauth2.googleapis.com/token').
-        with(body: { grant_type: 'authorization_code', code: code,
-          client_id: FAKE_GOOGLE_CLIENT_ID, client_secret: FAKE_GOOGLE_CLIENT_SECRET,
-          redirect_uri: 'http://www.example.com/google_sign_in/callback' }).
-        to_return(status: 200, headers: { 'Content-Type' => 'application/json' }, body: JSON.generate(params))
+    def stub_token_for(code, **response_body)
+      stub_token_request(code, status: 200, response: response_body)
+    end
+
+    def stub_token_error_for(code, error:)
+      stub_token_request(code, status: 418, response: { error: error })
+    end
+
+    def stub_token_request(code, status:, response:)
+      stub_request(:post, 'https://oauth2.googleapis.com/token').with(
+        body: {
+          grant_type: 'authorization_code',
+          code: code,
+          client_id: FAKE_GOOGLE_CLIENT_ID,
+          client_secret: FAKE_GOOGLE_CLIENT_SECRET,
+          redirect_uri: 'http://www.example.com/google_sign_in/callback'
+        }
+      ).to_return(
+        status: status,
+        headers: { 'Content-Type' => 'application/json' },
+        body: JSON.generate(response)
+      )
     end
 end


### PR DESCRIPTION
Rescue unhandled OAuth2::Error for access token requests and pass to the app, just like authorization request errors. Ref #31.