### PR TITLE
Skip forgery protection on POST /authorization

### DIFF
--- a/app/controllers/google_sign_in/authorizations_controller.rb
+++ b/app/controllers/google_sign_in/authorizations_controller.rb
@@ -1,6 +1,8 @@
 require 'securerandom'
 
 class GoogleSignIn::AuthorizationsController < GoogleSignIn::BaseController
+  skip_forgery_protection only: :create
+
   def create
     redirect_to login_url(scope: 'openid profile email', state: state),
       flash: { proceed_to: params.require(:proceed_to), state: state }


### PR DESCRIPTION
Due to some issues with Rails sessions expiry time and browsers restoring open pages/tabs with stale CSRF tokens but expired sessions (see https://github.com/rails/rails/issues/21948), posting to `/authorization` fails for some users due to failed CSRF checks.

Since this endpoint simply redirects to initiate the Google OAuth flow, there's nothing to be compromised by forging that request. It's similar to disabling CSRF protection on login.