### PR TITLE
Handle missing proceed_to URL in GET /callback

### DIFF
--- a/lib/google_sign_in/redirect_protector.rb
+++ b/lib/google_sign_in/redirect_protector.rb
@@ -9,8 +9,8 @@ module GoogleSignIn
     QUALIFIED_URL_PATTERN = /\A#{URI::DEFAULT_PARSER.make_regexp}\z/
 
     def ensure_same_origin(target, source)
-      if target =~ QUALIFIED_URL_PATTERN && origin_of(target) != origin_of(source)
-        raise Violation, "Redirect target #{target} does not have same origin as request (expected #{origin_of(source)})"
+      if target.blank? || (target =~ QUALIFIED_URL_PATTERN && origin_of(target) != origin_of(source))
+        raise Violation, "Redirect target #{target.inspect} does not have same origin as request (expected #{origin_of(source)})"
       end
     end
 

--- a/test/controllers/callbacks_controller_test.rb
+++ b/test/controllers/callbacks_controller_test.rb
@@ -101,6 +101,11 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
     assert_response :bad_request
   end
 
+  test "receiving no proceed_to URL" do
+    get google_sign_in.callback_url(code: '4/SgCpHSVW5-Cy', state: 'invalid')
+    assert_response :bad_request
+  end
+
   private
     def stub_token_for(code, **response_body)
       stub_token_request(code, status: 200, response: response_body)

--- a/test/models/redirect_protector_test.rb
+++ b/test/models/redirect_protector_test.rb
@@ -20,6 +20,12 @@ class GoogleSignIn::RedirectProtectorTest < ActiveSupport::TestCase
     end
   end
 
+  test "disallows empty URL target" do
+    assert_raises GoogleSignIn::RedirectProtector::Violation do
+      GoogleSignIn::RedirectProtector.ensure_same_origin nil, 'https://basecamp.com'
+    end
+  end
+
   test "allows URL target with same origin as source" do
     assert_nothing_raised do
       GoogleSignIn::RedirectProtector.ensure_same_origin 'https://basecamp.com', 'https://basecamp.com'


### PR DESCRIPTION
This can happen if `/callback` is accessed directly and not via a redirect from `POST /authorization`, which sets `flash[:proceed_to]`. In this case we don't have an URL to redirect back with the error.

We used to return a 422 in this case, as it was indirectly handled by checking the presence of `flash[:state]`. However, this was changed in https://github.com/basecamp/google_sign_in/commit/f26af121fbb280fe0262cdf32dbc00e2a396f910, to continue redirecting to the app including the error instead. When the whole `flash` is missing, we now get a 500 error as a consequence of trying to redirect to `nil`, so this addresses that by returning the same error as when an invalid `proceed_to` URL is provided, returning a `400 Bad Request` response. 