### PR TITLE
Fix: make test suite pass on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ cache: bundler
 before_install: gem update --system && gem install bundler -v 1.17.3
 
 rvm:
-  - 2.3
-  - 2.4
   - 2.5
   - 2.6
   - ruby-head

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    google_sign_in (1.1.2)
+    google_sign_in (1.2.0)
       google-id-token (>= 1.4.0)
       oauth2 (>= 1.4.0)
       rails (>= 5.2.0)


### PR DESCRIPTION
Commit 70ad36307 bumped the version of the gem to 1.2.0 without running "bundle" to also update the version in Gemfile.lock.

Tests have been [failing on Travis CI](https://travis-ci.org/github/basecamp/google_sign_in/jobs/690398898) since because of this:

> You are trying to install in deployment mode after changing
> your Gemfile. Run `bundle install` elsewhere and add the
> updated Gemfile.lock to version control.

Morever, starting from #44 this library depends on [Rails 6 which requires Ruby 2.5.0 or newer](https://guides.rubyonrails.org/v6.0/upgrading_ruby_on_rails.html#ruby-versions). 
For that reason, older versions of Ruby have been removed from the Travis CI configuration, as they would inherently fail.

