### PR TITLE
Make compatible with Rails 7

### DIFF
--- a/app/controllers/google_sign_in/authorizations_controller.rb
+++ b/app/controllers/google_sign_in/authorizations_controller.rb
@@ -5,7 +5,7 @@ class GoogleSignIn::AuthorizationsController < GoogleSignIn::BaseController
 
   def create
     redirect_to login_url(scope: 'openid profile email', state: state),
-      flash: { proceed_to: params.require(:proceed_to), state: state }
+      allow_other_host: true, flash: { proceed_to: params.require(:proceed_to), state: state }
   end
 
   private


### PR DESCRIPTION
When upgrading to Rails 7 alpha 2 the new unsafe redirect protection conflicts with this gem. This simply allows the unsafe_redirect.