### PR TITLE
Small API changes to allow client applications to use google APIs

### DIFF
--- a/app/controllers/google_sign_in/authorizations_controller.rb
+++ b/app/controllers/google_sign_in/authorizations_controller.rb
@@ -10,7 +10,11 @@ class GoogleSignIn::AuthorizationsController < GoogleSignIn::BaseController
 
   private
     def login_url(**params)
-      client.auth_code.authorize_url(prompt: 'login', **params)
+      if GoogleSignIn.require_refresh_token
+        client.auth_code.authorize_url(access_type: :offline, approval_prompt: :force, **params)
+      else
+        client.auth_code.authorize_url(prompt: 'login', **params)
+      end
     end
 
     def state

--- a/app/controllers/google_sign_in/authorizations_controller.rb
+++ b/app/controllers/google_sign_in/authorizations_controller.rb
@@ -4,7 +4,7 @@ class GoogleSignIn::AuthorizationsController < GoogleSignIn::BaseController
   skip_forgery_protection only: :create
 
   def create
-    redirect_to login_url(scope: 'openid profile email', state: state),
+    redirect_to login_url(scope: "openid profile email #{GoogleSignIn.extra_scopes&.join(" ")}", state: state),
       allow_other_host: true, flash: { proceed_to: params.require(:proceed_to), state: state }
   end
 

--- a/app/controllers/google_sign_in/callbacks_controller.rb
+++ b/app/controllers/google_sign_in/callbacks_controller.rb
@@ -3,48 +3,51 @@ require 'google_sign_in/redirect_protector'
 class GoogleSignIn::CallbacksController < GoogleSignIn::BaseController
   def show
     redirect_to proceed_to_url, flash: { google_sign_in: google_sign_in_response }
-  rescue GoogleSignIn::RedirectProtector::Violation => error
-    logger.error error.message
+  rescue GoogleSignIn::RedirectProtector::Violation => e
+    logger.error e.message
     head :bad_request
   end
 
   private
-    def proceed_to_url
-      flash[:proceed_to].tap { |url| GoogleSignIn::RedirectProtector.ensure_same_origin(url, request.url) }
-    end
 
-    def google_sign_in_response
-      if valid_request? && params[:code].present?
-        { id_token: id_token, access_token: access_token, refresh_token: refresh_token }
-      else
-        { error: error_message_for(params[:error]) }
-      end
-    rescue OAuth2::Error => error
-      { error: error_message_for(error.code) }
-    end
+  def proceed_to_url
+    flash[:proceed_to].tap { |url| GoogleSignIn::RedirectProtector.ensure_same_origin(url, request.url) }
+  end
 
-    def valid_request?
-      flash[:state].present? && params[:state] == flash[:state]
+  def google_sign_in_response
+    if valid_request? && params[:code].present?
+      response = { id_token: id_token }
+      response[:refresh_token] = refresh_token if refresh_token
+      response[:access_token] = access_token unless refresh_token
+      response
+    else
+      { error: error_message_for(params[:error]) }
     end
+  rescue OAuth2::Error => e
+    { error: error_message_for(e.code) }
+  end
 
+  def valid_request?
+    flash[:state].present? && params[:state] == flash[:state]
+  end
 
-    def token
-      @token ||= client.auth_code.get_token(params[:code])
-    end
+  def token
+    @token ||= client.auth_code.get_token(params[:code])
+  end
 
-    def id_token
-      token['id_token']
-    end
+  def id_token
+    token['id_token']
+  end
 
-    def access_token
-      token.token
-    end
+  def access_token
+    token.token
+  end
 
-    def refresh_token
-      token.refresh_token
-    end
+  def refresh_token
+    token.refresh_token
+  end
 
-    def error_message_for(error_code)
-      error_code.presence_in(GoogleSignIn::OAUTH2_ERRORS) || "invalid_request"
-    end
+  def error_message_for(error_code)
+    error_code.presence_in(GoogleSignIn::OAUTH2_ERRORS) || 'invalid_request'
+  end
 end

--- a/app/controllers/google_sign_in/callbacks_controller.rb
+++ b/app/controllers/google_sign_in/callbacks_controller.rb
@@ -15,7 +15,7 @@ class GoogleSignIn::CallbacksController < GoogleSignIn::BaseController
 
     def google_sign_in_response
       if valid_request? && params[:code].present?
-        { id_token: id_token, raw_token: @token.to_json }
+        { id_token: id_token, access_token: access_token, refresh_token: refresh_token }
       else
         { error: error_message_for(params[:error]) }
       end
@@ -27,9 +27,21 @@ class GoogleSignIn::CallbacksController < GoogleSignIn::BaseController
       flash[:state].present? && params[:state] == flash[:state]
     end
 
-    def id_token
+
+    def token
       @token ||= client.auth_code.get_token(params[:code])
-      @token['id_token']
+    end
+
+    def id_token
+      token['id_token']
+    end
+
+    def access_token
+      token.token
+    end
+
+    def refresh_token
+      token.refresh_token
     end
 
     def error_message_for(error_code)

--- a/app/controllers/google_sign_in/callbacks_controller.rb
+++ b/app/controllers/google_sign_in/callbacks_controller.rb
@@ -15,7 +15,7 @@ class GoogleSignIn::CallbacksController < GoogleSignIn::BaseController
 
     def google_sign_in_response
       if valid_request? && params[:code].present?
-        { id_token: id_token }
+        { id_token: id_token, access_token: access_token }
       else
         { error: error_message_for(params[:error]) }
       end
@@ -28,7 +28,13 @@ class GoogleSignIn::CallbacksController < GoogleSignIn::BaseController
     end
 
     def id_token
-      client.auth_code.get_token(params[:code])['id_token']
+      @token ||= client.auth_code.get_token(params[:code])
+      @token['id_token']
+    end
+
+    def access_token
+      @token ||= client.auth_code.get_token(params[:code])
+      @token.token
     end
 
     def error_message_for(error_code)

--- a/app/controllers/google_sign_in/callbacks_controller.rb
+++ b/app/controllers/google_sign_in/callbacks_controller.rb
@@ -15,7 +15,7 @@ class GoogleSignIn::CallbacksController < GoogleSignIn::BaseController
 
     def google_sign_in_response
       if valid_request? && params[:code].present?
-        { id_token: id_token, access_token: access_token }
+        { id_token: id_token, raw_token: @token.to_json }
       else
         { error: error_message_for(params[:error]) }
       end
@@ -30,11 +30,6 @@ class GoogleSignIn::CallbacksController < GoogleSignIn::BaseController
     def id_token
       @token ||= client.auth_code.get_token(params[:code])
       @token['id_token']
-    end
-
-    def access_token
-      @token ||= client.auth_code.get_token(params[:code])
-      @token.token
     end
 
     def error_message_for(error_code)

--- a/lib/google_sign_in.rb
+++ b/lib/google_sign_in.rb
@@ -5,6 +5,7 @@ module GoogleSignIn
   mattr_accessor :client_id
   mattr_accessor :client_secret
   mattr_accessor :extra_scopes
+  mattr_accessor :require_refresh_token
 
   # https://tools.ietf.org/html/rfc6749#section-4.1.2.1
   authorization_request_errors = %w[

--- a/lib/google_sign_in.rb
+++ b/lib/google_sign_in.rb
@@ -4,6 +4,7 @@ require 'active_support/rails'
 module GoogleSignIn
   mattr_accessor :client_id
   mattr_accessor :client_secret
+  mattr_accessor :extra_scopes
 
   # https://tools.ietf.org/html/rfc6749#section-4.1.2.1
   authorization_request_errors = %w[

--- a/lib/google_sign_in/engine.rb
+++ b/lib/google_sign_in/engine.rb
@@ -11,6 +11,7 @@ module GoogleSignIn
         GoogleSignIn.client_id     = config.google_sign_in.client_id || app.credentials.dig(:google_sign_in, :client_id)
         GoogleSignIn.client_secret = config.google_sign_in.client_secret || app.credentials.dig(:google_sign_in, :client_secret)
         GoogleSignIn.extra_scopes = config.google_sign_in.extra_scopes || []
+        GoogleSignIn.require_refresh_token = config.google_sign_in.require_refresh_token || false
       end
     end
 

--- a/lib/google_sign_in/engine.rb
+++ b/lib/google_sign_in/engine.rb
@@ -10,6 +10,7 @@ module GoogleSignIn
       config.after_initialize do
         GoogleSignIn.client_id     = config.google_sign_in.client_id || app.credentials.dig(:google_sign_in, :client_id)
         GoogleSignIn.client_secret = config.google_sign_in.client_secret || app.credentials.dig(:google_sign_in, :client_secret)
+        GoogleSignIn.extra_scopes = config.google_sign_in.extra_scopes || []
       end
     end
 


### PR DESCRIPTION
This pull request is backwards compatible, but has also some small API changes to allow client applications to use google APIs after the user authenticate.
The client applications have the options to add extra scopes to the authentication, and also to request a refresh_token to work "offline" 