### PR TITLE
Clear entries from session on verified callbacks

### DIFF
--- a/app/controllers/google_sign_in/callbacks_controller.rb
+++ b/app/controllers/google_sign_in/callbacks_controller.rb
@@ -3,6 +3,7 @@ require 'google_sign_in/redirect_protector'
 class GoogleSignIn::CallbacksController < GoogleSignIn::BaseController
   def show
     redirect_to proceed_to_url, flash: { google_sign_in: google_sign_in_response }
+    clear_redeemed_flash_keys if valid_request?
   rescue GoogleSignIn::RedirectProtector::Violation => error
     logger.error error.message
     head :bad_request
@@ -33,5 +34,11 @@ class GoogleSignIn::CallbacksController < GoogleSignIn::BaseController
 
     def error_message_for(error_code)
       error_code.presence_in(GoogleSignIn::OAUTH2_ERRORS) || "invalid_request"
+    end
+
+    # Clear keys we don't need anymore to reduce the session size.
+    def clear_redeemed_flash_keys
+      flash.delete(:proceed_to)
+      flash.delete(:state)
     end
 end

--- a/google_sign_in.gemspec
+++ b/google_sign_in.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'oauth2', '>= 1.4.0'
 
   s.files      = `git ls-files`.split("\n")
-  s.test_files = `git ls-files -- tgem updatest/*`.split("\n")
+  s.test_files = `git ls-files -- test/*`.split("\n")
 end

--- a/test/controllers/callbacks_controller_test.rb
+++ b/test/controllers/callbacks_controller_test.rb
@@ -11,6 +11,8 @@ class GoogleSignIn::CallbacksControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to 'http://www.example.com/login'
     assert_equal 'eyJhbGciOiJSUzI', flash[:google_sign_in][:id_token]
     assert_nil flash[:google_sign_in][:error]
+    assert_nil flash[:state]
+    assert_nil flash[:proceed_to]
   end
 
   # Authorization request errors: https://tools.ietf.org/html/rfc6749#section-4.1.2.1


### PR DESCRIPTION
We use the flash to store potentially very long values such as the `state` or the redirect url. This adds to the session storage needs, which can be problematic when using cookies as session storage.

@basecamp/sip 
