### PR TITLE
Update the google_sign_in keys to be strings rather than symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ This gem provides a `google_sign_in_button` helper. It generates a button which 
 ```
 
 The `proceed_to` argument is required. After authenticating with Google, the gem redirects to `proceed_to`, providing
-a Google ID token in `flash[:google_sign_in][:id_token]` or an [OAuth authorizaton code grant error](https://tools.ietf.org/html/rfc6749#section-4.1.2.1)
-in `flash[:google_sign_in][:error]`. Your application decides what to do with it:
+a Google ID token in `flash["google_sign_in"]["id_token"]` or an [OAuth authorizaton code grant error](https://tools.ietf.org/html/rfc6749#section-4.1.2.1)
+in `flash["google_sign_in"]["error"]`. Your application decides what to do with it:
 
 ```ruby
 # config/routes.rb
@@ -119,9 +119,9 @@ class LoginsController < ApplicationController
 
   private
     def authenticate_with_google
-      if id_token = flash[:google_sign_in][:id_token]
+      if id_token = flash["google_sign_in"]["id_token"]
         User.find_by google_id: GoogleSignIn::Identity.new(id_token).user_id
-      elsif error = flash[:google_sign_in][:error]
+      elsif error = flash["google_sign_in"]["error"]
         logger.error "Google authentication error: #{error}"
         nil
       end


### PR DESCRIPTION
`flash[:google_sign_in][:id_token]` is `nil` on Rails 7.1 because `flash[:google_sign_in]` is a Hash.

I suspect it used to be HashWithIndifferentAccess before.

The fix is to switch over to strings when accessing Hash items.