### PR TITLE
Remove unnecessary files from the gem package

### DIFF
--- a/google_sign_in.gemspec
+++ b/google_sign_in.gemspec
@@ -13,6 +13,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'google-id-token', '>= 1.4.0'
   s.add_dependency 'oauth2', '>= 1.4.0'
 
-  s.files      = `git ls-files`.split("\n")
-  s.test_files = `git ls-files -- test/*`.split("\n")
+  s.files = Dir["{app,config,lib}/**/*", "MIT-LICENSE", "README.md", "SECURITY.md"]
 end


### PR DESCRIPTION
The full contents of the gem file will be:

- /app/controllers/google_sign_in/authorizations_controller.rb
- /app/controllers/google_sign_in/base_controller.rb
- /app/controllers/google_sign_in/callbacks_controller.rb
- /app/helpers/google_sign_in/button_helper.rb
- /config/routes.rb
- /lib/google_sign_in/engine.rb
- /lib/google_sign_in/identity.rb
- /lib/google_sign_in.rb
- /lib/google_sign_in/redirect_protector.rb
- /MIT-LICENSE
- /README.md
- /SECURITY.md